### PR TITLE
simple utility to get the class name for a VUI icon based on extension

### DIFF
--- a/src/__tests__/getIconClassName.js
+++ b/src/__tests__/getIconClassName.js
@@ -1,0 +1,23 @@
+'use strict';
+
+jest.dontMock('../getIconClassName.js');
+
+var getIconClassName = require('../getIconClassName.js');
+
+describe('GetIconClassName', function() {
+
+	['wav', 'mp3'].forEach(function(extension) {
+		it('should should return audio icon for "' + extension + '"', function() {
+			var type = getIconClassName(extension);
+			expect(type).toEqual('audio');
+		});
+	});
+
+	['abc'].forEach(function(extension) {
+		it('should should return generic type for "' + extension + '"', function() {
+			var type = getIconClassName(extension);
+			expect(type).toEqual('generic');
+		});
+	});
+
+});

--- a/src/getIconClassName.js
+++ b/src/getIconClassName.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var iconExtensionMap = {
+	'audio': ['mp3', 'wav']
+};
+
+function getIconClassName(extension) {
+	for (var className in iconExtensionMap) {
+		if (iconExtensionMap[className].indexOf(extension) > -1) {
+			return className;
+		}
+	}
+	return 'generic';
+}
+
+module.exports = getIconClassName;


### PR DESCRIPTION
Just supports audio for now, but will eventually only really need to support the file types we don't explicitly have a plugin for (i.e. ones the generic plugin will render).