### PR TITLE
SCSS file for the component at the root

### DIFF
--- a/fileViewer.scss
+++ b/fileViewer.scss
@@ -1,0 +1,10 @@
+@import 'bower_components/vui-button/button';
+@import 'bower_components/vui-icons/icons';
+
+.vui-fileviewer {
+
+	@import './src/plugins/generic/generic.scss';
+	@import './src/plugins/html/html.scss';
+	@import './src/plugins/pdf/pdf.scss';
+
+}

--- a/sample/app.scss
+++ b/sample/app.scss
@@ -1,4 +1,4 @@
-@import '../src/fileViewer.scss';
+@import '../fileViewer.scss';
 
 body {
 	background: #fafafa;

--- a/src/fileViewer.scss
+++ b/src/fileViewer.scss
@@ -1,8 +1,0 @@
-.vui-fileviewer {
-
-	@import './plugins/generic/generic.scss';
-	@import './plugins/html/html.scss';
-
-	@import './plugins/pdf/pdf.scss';
-
-}

--- a/src/plugins/generic/generic.scss
+++ b/src/plugins/generic/generic.scss
@@ -1,6 +1,3 @@
-@import 'bower_components/vui-button/button.scss';
-@import 'bower_components/vui-icons/icons.scss';
-
 .vui-fileviewer-generic {
 
 	background-color: #ffffff;


### PR DESCRIPTION
@omsmith, FYI

Recommended by @dbatiste, this should allow things to work whether the component is fetched via NPM or Bower.

When fetched via Bower:
Component will be in `bower_components` and button/icons will be siblings. Including them from `bower_compeonts/vui-button/etc` will work.

When fetched via NPM:
Component will be in `node_modules` and have its own `bower_components` directory, which is why this file needs to be at the root of the project.