### PR TITLE
fixing "findComponentRoot" errors by removing children of IFRAME element

### DIFF
--- a/src/plugins/html/nativeViewer.js
+++ b/src/plugins/html/nativeViewer.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var React = require('react'),
-	GenericViewer = require('../generic/viewer.js');
+var React = require('react');
 
 var NativeViewer = React.createClass({
 	componentDidMount: function() {
@@ -29,7 +28,6 @@ var NativeViewer = React.createClass({
 			className="vui-fileviewer-html-native"
 			ref="wrapper"
 			style={style}>
-			<GenericViewer {...this.props} />;
 		</iframe>;
 	}
 });


### PR DESCRIPTION
@omsmith, @jstefaniuk-d2l: happened upon this bug again while writing tests, this fixes it. It's because `<div>` elements can't be nested inside IFRAMEs.