### PR TITLE
Fix rimraf on windows for prebuild-sample

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React component for viewing files",
   "main": "src/fileViewer.js",
   "scripts": {
-    "prebuild-sample": "rimraf ./sample/dist && mkdir ./sample/dist",
+    "prebuild-sample": "rimraf ./sample/dist .\\sample\\dist && mkdir ./sample/dist",
     "build-sample": "browserify -s app ./sample/app.js > ./sample/dist/app.js && node-sass ./sample/app.scss ./sample/dist/app.css",
     "lint": "eslint src",
     "postinstall": "bower install",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React component for viewing files",
   "main": "src/fileViewer.js",
   "scripts": {
-    "prebuild-sample": "rimraf ./sample/dist .\\sample\\dist && mkdirp ./sample/dist",
+    "prebuild-sample": "rimraf ./sample/dist && mkdirp ./sample/dist",
     "build-sample": "browserify -s app ./sample/app.js > ./sample/dist/app.js && node-sass ./sample/app.scss ./sample/dist/app.css",
     "lint": "eslint src",
     "postinstall": "bower install",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React component for viewing files",
   "main": "src/fileViewer.js",
   "scripts": {
-    "prebuild-sample": "rimraf ./sample/dist .\\sample\\dist && mkdir ./sample/dist",
+    "prebuild-sample": "rimraf ./sample/dist .\\sample\\dist && mkdirp ./sample/dist",
     "build-sample": "browserify -s app ./sample/app.js > ./sample/dist/app.js && node-sass ./sample/app.scss ./sample/dist/app.css",
     "lint": "eslint src",
     "postinstall": "bower install",
@@ -37,6 +37,7 @@
     "eslint-config-brightspace": "^0.0.2",
     "http-server": "^0.8.5",
     "jest-cli": "^0.5.7",
+    "mkdirp": "^0.5.1",
     "node-sass": "^3.3.3",
     "reactify": "^1.1.1",
     "rimraf": "^2.4.3",


### PR DESCRIPTION
https://github.com/isaacs/rimraf/blob/master/README.md

"CLI

If installed with npm install rimraf -g it can be used as a global command rimraf <path [<path ...] which is useful for cross platform support."