### PR TITLE
fix(package) bower should be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "react": "^0.13.3"
   },
   "dependencies": {
+    "bower": "^1.6.5",
     "d2l-intl": "^0.2.1",
     "reactify": "^1.1.1"
   },
   "devDependencies": {
     "babel-jest": "^5.3.0",
-    "bower": "^1.5.3",
     "browserify": "^11.1.0",
     "coveralls": "^2.11.4",
     "eslint": "^1.5.1",


### PR DESCRIPTION
it's being used in postinstall, so needs to be present

@dlockhart @awikkerink 