### PR TITLE
Instead of using the top of the fileViewer to decide it's height, pass in the chromeElement which is above it

### DIFF
--- a/src/fileViewer.js
+++ b/src/fileViewer.js
@@ -36,7 +36,8 @@ var FileViewer = React.createClass({
 	propTypes: {
 		src: React.PropTypes.string.isRequired,
 		locale: React.PropTypes.string,
-		progressCallback: React.PropTypes.func
+		progressCallback: React.PropTypes.func,
+		chromeElement: React.PropTypes.object
 	},
 	render: function() {
 		if (this.state.error) {

--- a/src/plugins/html/__tests__/viewerTests.js
+++ b/src/plugins/html/__tests__/viewerTests.js
@@ -60,7 +60,7 @@ describe('HTML Viewer', function() {
 		expect(removeEventListener.calledOnce).toBeTruthy();
 	});
 
-	it('should calls the progressCallback and pass 100 in as the value', function() {
+	it('should call the progressCallback and pass 100 in as the value', function() {
 
 		var progressFunc = jest.genMockFunction();
 
@@ -75,5 +75,34 @@ describe('HTML Viewer', function() {
 		expect(progressFunc.mock.calls.length).toBe(2);
 		expect(progressFunc.mock.calls[0][0]).toBe(0);
 		expect(progressFunc.mock.calls[1][0]).toBe(100);
+	});
+
+	it('should resize to the window height when no chromeElement is passed in', function() {
+		var setState = jest.genMockFunction();
+		Viewer.prototype.setState = setState;
+
+		TestUtils.renderIntoDocument(
+			<Viewer src='foo.bar' />
+		);
+
+		expect(setState).toBeCalledWith({ height : window.innerHeight });
+	});
+
+	it('should resize to the window height minus the height of the chromeElement', function() {
+		var setState = jest.genMockFunction();
+		Viewer.prototype.setState = setState;
+		var chromeHeight = 50;
+
+		var chrome = {
+			getBoundingClientRect : function() {
+				return {height : chromeHeight};
+			}
+		};
+
+		TestUtils.renderIntoDocument(
+			<Viewer src='foo.bar' chromeElement={chrome} />
+		);
+
+		expect(setState).toBeCalledWith({ height : window.innerHeight - chromeHeight });
 	});
 });

--- a/src/plugins/html/viewer.js
+++ b/src/plugins/html/viewer.js
@@ -17,8 +17,8 @@ var NativeViewer = React.createClass({
 		return { height: null };
 	},
 	handleResize: function() {
-		var rect = React.findDOMNode(this.refs.wrapper).getBoundingClientRect();
-		var height = (window.innerHeight - rect.top);
+		var chromeHeight = (this.props.chromeElement) ? this.props.chromeElement.getBoundingClientRect().height : 0;
+		var height = (window.innerHeight - chromeHeight);
 		this.setState({height: height});
 	},
 	propTypes: {

--- a/src/plugins/pdf/__tests__/nativeViewerTests.js
+++ b/src/plugins/pdf/__tests__/nativeViewerTests.js
@@ -31,4 +31,33 @@ describe('PDF Native Viewer', function() {
 		expect(progressFunc.mock.calls.length).toBe(1);
 		expect(progressFunc.mock.calls[0][0]).toBe(100);
 	});
+
+	it('should resize to the window height when no chromeElement is passed in', function() {
+		var setState = jest.genMockFunction();
+		NativeViewer.prototype.setState = setState;
+
+		TestUtils.renderIntoDocument(
+			<NativeViewer src='foo.bar' />
+		);
+
+		expect(setState).toBeCalledWith({ height : window.innerHeight });
+	});
+
+	it('should resize to the window height minus the height of the chromeElement', function() {
+		var setState = jest.genMockFunction();
+		NativeViewer.prototype.setState = setState;
+		var chromeHeight = 50;
+
+		var chrome = {
+			getBoundingClientRect : function() {
+				return {height : chromeHeight};
+			}
+		};
+
+		TestUtils.renderIntoDocument(
+			<NativeViewer src='foo.bar' chromeElement={chrome} />
+		);
+
+		expect(setState).toBeCalledWith({ height : window.innerHeight - chromeHeight });
+	});
 });

--- a/src/plugins/pdf/nativeViewer.js
+++ b/src/plugins/pdf/nativeViewer.js
@@ -18,8 +18,8 @@ var NativeViewer = React.createClass({
 		return { height: null };
 	},
 	handleResize: function() {
-		var rect = React.findDOMNode(this.refs.wrapper).getBoundingClientRect();
-		var height = (window.innerHeight - rect.top);
+		var chromeHeight = (this.props.chromeElement) ? this.props.chromeElement.getBoundingClientRect().height : 0;
+		var height = (window.innerHeight - chromeHeight);
 		this.setState({height: height});
 	},
 	updateProgress: function(progress) {


### PR DESCRIPTION
This is needed because the 'top' of the element may start elsewhere than the top of the page (like if you are animating the component with this pattern: https://www.google.com/design/spec/patterns/navigational-transitions.html#navigational-transitions-parent-to-child) 

It will also allow us to change the fileViewer's height when the chrome's height changes (once we have a more featured chrome)