### PR TITLE
Make the fileviewer fill the container which it is inside

### DIFF
--- a/fileViewer.scss
+++ b/fileViewer.scss
@@ -7,5 +7,5 @@
 	@import './src/plugins/html/html.scss';
 	@import './src/plugins/image/image.scss';
 	@import './src/plugins/pdf/pdf.scss';
-
+	height: 100%;
 }

--- a/src/plugins/html/__tests__/viewerTests.js
+++ b/src/plugins/html/__tests__/viewerTests.js
@@ -44,22 +44,6 @@ describe('HTML Viewer', function() {
 		expect(React.findDOMNode(iframe).src).toBe('foo.bar');
 	});
 
-	it('should add event listener when mounted', function() {
-		TestUtils.renderIntoDocument(<Viewer src='foo.bar' />);
-		expect(addEventListener.calledOnce).toBeTruthy();
-	});
-
-	it('should remove event listener when unmounted', function() {
-		var elem = TestUtils.renderIntoDocument(
-			<Viewer src='foo.bar' />
-		);
-		var success = React.unmountComponentAtNode(
-			React.findDOMNode(elem).parentNode
-		);
-		expect(success).toBeTruthy();
-		expect(removeEventListener.calledOnce).toBeTruthy();
-	});
-
 	it('should calls the progressCallback and pass 100 in as the value', function() {
 
 		var progressFunc = jest.genMockFunction();

--- a/src/plugins/html/html.scss
+++ b/src/plugins/html/html.scss
@@ -1,3 +1,4 @@
 .vui-fileviewer-html-native {
 	width: 100%;
+	height: 100%;
 }

--- a/src/plugins/html/viewer.js
+++ b/src/plugins/html/viewer.js
@@ -4,22 +4,7 @@ var React = require('react');
 
 var NativeViewer = React.createClass({
 	componentDidMount: function() {
-		window.addEventListener('resize', this.handleResize);
-		this.handleResize();
 		this.updateProgress(0);
-		document.body.style.overflow = 'hidden';
-	},
-	componentWillUnmount: function() {
-		window.removeEventListener('resize', this.handleResize);
-		document.body.style.overflow = 'visible';
-	},
-	getInitialState: function() {
-		return { height: null };
-	},
-	handleResize: function() {
-		var rect = React.findDOMNode(this.refs.wrapper).getBoundingClientRect();
-		var height = (window.innerHeight - rect.top);
-		this.setState({height: height});
 	},
 	propTypes: {
 		src: React.PropTypes.string.isRequired
@@ -33,13 +18,10 @@ var NativeViewer = React.createClass({
 		this.updateProgress(100);
 	},
 	render: function() {
-		var style = this.state.height ? { height: this.state.height } : null;
 		return <iframe
 			onLoad={this.handleOnLoad}
 			src={this.props.src}
-			className="vui-fileviewer-html-native"
-			ref="wrapper"
-			style={style}>
+			className="vui-fileviewer-html-native">
 		</iframe>;
 	}
 });

--- a/src/plugins/pdf/nativeViewer.js
+++ b/src/plugins/pdf/nativeViewer.js
@@ -5,22 +5,7 @@ var React = require('react'),
 
 var NativeViewer = React.createClass({
 	componentDidMount: function() {
-		window.addEventListener('resize', this.handleResize);
-		document.body.style.overflow = 'hidden';
-		this.handleResize();
 		this.updateProgress(100);
-	},
-	componentWillUnmount: function() {
-		window.removeEventListener('resize', this.handleResize);
-		document.body.style.overflow = 'visible';
-	},
-	getInitialState: function() {
-		return { height: null };
-	},
-	handleResize: function() {
-		var rect = React.findDOMNode(this.refs.wrapper).getBoundingClientRect();
-		var height = (window.innerHeight - rect.top);
-		this.setState({height: height});
 	},
 	updateProgress: function(progress) {
 		if (this.props.progressCallback) {
@@ -28,13 +13,10 @@ var NativeViewer = React.createClass({
 		}
 	},
 	render: function() {
-		var style = this.state.height ? { height: this.state.height } : null;
 		return <object
 			data={this.props.src}
 			type="application/pdf"
-			className="vui-fileviewer-pdf-native"
-			ref="wrapper"
-			style={style}>
+			className="vui-fileviewer-pdf-native">
 			<GenericViewer {...this.props} />
 		</object>;
 	}

--- a/src/plugins/pdf/pdf.scss
+++ b/src/plugins/pdf/pdf.scss
@@ -1,3 +1,4 @@
 .vui-fileviewer-pdf-native {
 	width: 100%;
+	height: 100%;
 }


### PR DESCRIPTION
Instead of filling the remaining amount of the screen we just fill whichever container it was placed inside