### PR TITLE
Swap out startsWith for indexOf = 0, which is supported in ie

### DIFF
--- a/src/getIconClassName.js
+++ b/src/getIconClassName.js
@@ -7,7 +7,7 @@ var iconExtensionMap = {
 
 function getIconClassName(mimeType) {
 	for (var pattern in iconExtensionMap) {
-		if (mimeType.startsWith(pattern)) {
+		if (mimeType.indexOf(pattern) === 0) {
 			return iconExtensionMap[pattern];
 		}
 	}


### PR DESCRIPTION
I can't currently test this due to oauth2 errors, but it should fix the error @Surekh was having:
https://trello.com/c/n4Xf6m29/94-issue-react-file-viewer-safari-ie10-generic-plugin-does-not-show-the-download-button