### PR TITLE
RTL and localized messages support

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/fileViewer.js",
   "scripts": {
     "prebuild-sample": "rimraf ./sample/dist && mkdirp ./sample/dist",
-    "build-sample": "browserify -s app ./sample/app.js > ./sample/dist/app.js && node-sass ./sample/app.scss ./sample/dist/app.css",
+    "build-sample": "browserify -t babelify -s app ./sample/app.js > ./sample/dist/app.js && node-sass ./sample/app.scss ./sample/dist/app.css",
     "lint": "eslint src",
     "postinstall": "bower install",
     "report-coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
@@ -31,10 +31,12 @@
   "dependencies": {
     "bower": "^1.6.5",
     "d2l-intl": "^0.2.1",
+    "react-frau-intl": "^0.1.2",
     "reactify": "^1.1.1"
   },
   "devDependencies": {
     "babel-jest": "^5.3.0",
+    "babelify": "^6.1.2",
     "browserify": "^11.1.0",
     "coveralls": "^2.11.4",
     "eslint": "^1.5.1",

--- a/sample/app.js
+++ b/sample/app.js
@@ -28,7 +28,11 @@ var Main = React.createClass({
 		this.setState({file: files[event.target.selectedIndex - 1]});
 	},
 	localeSelected: function(event) {
-		this.setState({locale: event.target.value});
+		var dir = event.target.value === 'ar-SA' ? 'rtl' : 'ltr';
+		this.setState({
+			locale: event.target.value,
+			direction: dir
+		});
 	},
 	logProgress: function(progress) {
 		console.log(this.state.file.src + ' - ' + progress + '/100');
@@ -40,7 +44,7 @@ var Main = React.createClass({
 				src={'files/' + this.state.file.src}
 				srcdownload={'files/' + this.state.file.src}
 				locale={this.state.locale} /> : null;
-		return <div>
+		return <div dir={this.state.direction}>
 			<div className="file-selector">
 				<h1>File Viewer Sample Application</h1>
 				<label>

--- a/src/fileViewer.js
+++ b/src/fileViewer.js
@@ -2,7 +2,9 @@
 
 var React = require('react'),
 	FileViewerResolved = require('./fileViewerResolved'),
-	fileInfoProvider = require('./fileInfoProvider');
+	fileInfoProvider = require('./fileInfoProvider'),
+	i18n = require('react-frau-intl').i18n,
+	getMessages = require('./getMessages');
 
 var FileViewer = React.createClass({
 	componentDidMount: function() {
@@ -45,8 +47,12 @@ var FileViewer = React.createClass({
 		if (!this.state.info) {
 			return null;
 		}
-		return <FileViewerResolved
+		var messages = getMessages(this.props.locale);
+		var IntlFileViewer = i18n(FileViewerResolved);
+
+		return <IntlFileViewer
 			{...this.props}
+			messages={messages}
 			filename={this.state.info.filename}
 			mimeType={this.state.info.mimeType}
 			size={this.state.info.size} />;

--- a/src/getMessages.js
+++ b/src/getMessages.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var languages = {
+	'en': require('./lang/en.json')
+};
+
+function getMessages(lang) {
+	return (languages[lang]) ? languages[lang] : languages.en;
+}
+
+module.exports = getMessages;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1,0 +1,7 @@
+{
+	"Plugins": {
+		"Generic": {
+			"Download": "Download"
+		}
+	}
+}

--- a/src/plugins/generic/download.js
+++ b/src/plugins/generic/download.js
@@ -3,6 +3,10 @@
 var React = require('react');
 
 var Download = React.createClass({
+	contextTypes : {
+		getIntlMessage: React.PropTypes.func,
+		formatMessage: React.PropTypes.func
+	},
 	propTypes: {
 		src: React.PropTypes.string
 	},
@@ -10,11 +14,12 @@ var Download = React.createClass({
 		document.location.href = this.props.src;
 	},
 	render: function() {
+		var downloadButtonText = this.context.getIntlMessage('Plugins.Generic.Download');
 		if (!this.props.src) {
 			return null;
 		}
 		return <div className="vui-fileviewer-generic-download">
-			<button onClick={this.download}>Download</button>
+			<button onClick={this.download}>{downloadButtonText}</button>
 		</div>;
 	}
 });

--- a/src/plugins/generic/generic.scss
+++ b/src/plugins/generic/generic.scss
@@ -14,12 +14,19 @@
 			display: block;
 			clear: both;
 		}
+		[dir="rtl"] & {
+			text-align: right;
+		}
 	}
 
 	.vui-fileviewer-icon {
 		float: left;
 		margin: 15px 40px 0 20px;
 		vertical-align: middle;
+
+		[dir="rtl"] & {
+			float: right;
+		}
 	}
 
 	.vui-fileviewer-icon-audio {
@@ -36,6 +43,9 @@
 
 	.vui-fileviewer-generic-main {
 		float: left;
+		[dir="rtl"] & {
+			float: right;
+		}
 	}
 
 	.vui-fileviewer-generic-filename {


### PR DESCRIPTION
Added some styling for RTL languages, only applies to the generic plugin at this point.
Brought in react-frau-intl to handle localization of messages, specifically the word
'download' that appears in the generic viewer.