### PR TITLE
Cancel image

### DIFF
--- a/src/plugins/image/viewer.js
+++ b/src/plugins/image/viewer.js
@@ -14,8 +14,12 @@ var ImageViewer = React.createClass({
 			this.props.progressCallback(progress);
 		}
 	},
+	componentWillUnmount: function() {
+		// without this, the file continues to download after being removed from the DOM
+		React.findDOMNode(this.refs.image).src = '';
+	},
 	render: function() {
-		return <img src={this.props.src} alt="" className="vui-fileviewer-image" />;
+		return <img ref="image" src={this.props.src} alt="" className="vui-fileviewer-image" />;
 	}
 });
 


### PR DESCRIPTION
I was only able to reproduce the problem with images

I confirmed that the image was being removed from the DOM but still continued downloading. I found here: http://stackoverflow.com/questions/5278304/how-to-cancel-an-image-from-loading that setting the image src to "" interrupts the download, and that seems to work

Rally link: https://rally1.rallydev.com/#/44847733393d/detail/userstory/48178234085