### PR TITLE
Stretch the generic viewer out

### DIFF
--- a/src/plugins/generic/generic.scss
+++ b/src/plugins/generic/generic.scss
@@ -1,7 +1,8 @@
 .vui-fileviewer-generic {
 
 	padding: 10px;
-
+	width: 100%;
+	
 	.vui-fileviewer-generic-container {
 		background-color: #ffffff;
 		border: 1px solid #d4d4d4;


### PR DESCRIPTION
width: 90% was no good but without a setting at all it changes size based on
the contents, which is a bit weird inside the sequence viewer. All this will
probably get changed at some point when this view gets re-styled, but for now
100% looks best in the one place this is being used.