### PR TITLE
Fix alternate PDF viewer overflowing bounds of container

### DIFF
--- a/src/plugins/pdf/pdf.scss
+++ b/src/plugins/pdf/pdf.scss
@@ -14,6 +14,6 @@ $pdf-background-color: #404040;
 	padding: 5px 10px;
 	box-sizing: border-box;
 	text-align: center;
-	position: absolute;
+	position: relative;
     overflow: auto;
 }


### PR DESCRIPTION
If the PDF is wider than the container the fileviewer is placed in, when rendering with the alternate viewer, the container bounds are exceeded instead of the PDF scaling down to fit the available width. This issue is not visible in the sample app of this project but can be repro'd if consuming elsewhere.