### PR TITLE
In iOS an iFrame is rendered to fit the content despite what your CSS…

### DIFF
--- a/src/plugins/html/html.scss
+++ b/src/plugins/html/html.scss
@@ -1,3 +1,11 @@
+.vui-fileviewer-html-native-wrapper {
+	display: flex;
+	flex: 1;
+	min-height: 100%; /* fix for ie11 */
+	overflow: auto;
+	-webkit-overflow-scrolling:touch;
+}
+
 .vui-fileviewer-html-native {
 	display: flex;
 	flex: 1;

--- a/src/plugins/html/viewer.js
+++ b/src/plugins/html/viewer.js
@@ -18,11 +18,13 @@ var NativeViewer = React.createClass({
 		this.updateProgress(100);
 	},
 	render: function() {
-		return <iframe
-			onLoad={this.handleOnLoad}
-			src={this.props.src}
-			className="vui-fileviewer-html-native">
-		</iframe>;
+		return <div className="vui-fileviewer-html-native-wrapper">
+			<iframe
+				onLoad={this.handleOnLoad}
+				src={this.props.src}
+				className="vui-fileviewer-html-native">
+			</iframe>
+		</div>;
 	}
 });
 


### PR DESCRIPTION
… says it should do (aka 'seamless').

Unfortunately that means that non-responsive super-wide content breaks things for any app trying to
use the file viewer to show an HTML doc inside a container with a max width less than the content.
This new div around the iFrame fixes that.