### PR TITLE
fix sizing for generic viewer on small screen sizes

### DIFF
--- a/src/plugins/generic/generic.scss
+++ b/src/plugins/generic/generic.scss
@@ -3,6 +3,7 @@
 	background: linear-gradient(to bottom , #e0e5ea, #ffffff);
 	background-size: 100% 10.75rem;
 	background-repeat: no-repeat;
+	overflow: auto;
 
 	.vui-fileviewer-icon-audio {
 		@include vui-icon-file-audio-xlarge;


### PR DESCRIPTION
related to:
https://github.com/Brightspace/activity-viewer/pull/79
https://github.com/Brightspace/sequence-viewer/pull/143