### PR TITLE
Bump iframe version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "rimraf": "^2.4.3",
     "sinon": "^1.17.2",
     "sinon-as-promised": "^4.0.0",
-    "react-valence-ui-iframe": "git+https://github.com/Brightspace/react-valence-ui-iframe.git#v1.1.1"
+    "react-valence-ui-iframe": "git+https://github.com/CodeBaboon/react-valence-ui-iframe.git#fix-duplicate-nav"
   },
   "private": true,
   "browserify": {


### PR DESCRIPTION
**WIP** PLACEHOLDER PR

Once https://github.com/Brightspace/react-valence-ui-iframe/pull/12 is merged and a new release of the iframe is made I will update this PR to point to that new version.