### PR TITLE
Adding .repoInfo.d2l.json

### DIFF
--- a/.repoInfo.d2l.json
+++ b/.repoInfo.d2l.json
@@ -1,0 +1,9 @@
+{
+ "mirrormereProductId": 0,
+ "repoOwner": "email@d2l.com" | null,
+ "platform": ".net" | "js" | "php" | "go" | "ios" | "android",
+ "codeType": "service" | "library" | "prototype" | "not code",
+ "deployment": "prod" | "internal only" | "not deployed",
+ "devStatus": "active" | "maintenance" | "end of life",
+ "awsAccountNames": {"prod": "aws-account-name", "dev": "aws-account-name"} | null
+}

--- a/.repoInfo.d2l.json
+++ b/.repoInfo.d2l.json
@@ -1,9 +1,6 @@
 {
  "mirrormereProductId": 0,
- "repoOwner": "email@d2l.com" | null,
- "platform": ".net" | "js" | "php" | "go" | "ios" | "android",
- "codeType": "service" | "library" | "prototype" | "not code",
+ "codeType": "service" | "library" | "frapp" | "mobile app" | "infrastructure" | "script" | "prototype" | "not code",
  "deployment": "prod" | "internal only" | "not deployed",
- "devStatus": "active" | "maintenance" | "end of life",
- "awsAccountNames": {"prod": "aws-account-name", "dev": "aws-account-name"} | null
+ "isEndOfLife": true | false
 }


### PR DESCRIPTION
The InfoSec team is asking developers across D2L to add a .repoInfo.d2l.json file to the root of their repos to capture some basic metadata about each of D2L's repositories. Visit [InfoSec Process - RepoInfo](https://docs.dev.d2l/index.php/InfoSec_Process_-_RepoInfo) for a full description of what we're doing, the format for the .repoInfo.d2l.json file, and how adding this file helps D2L.

This PR was contains a template to make it easier for you to add the .repoInfo.d2l.json file to this repo, and it needs someone to populate it with the correct information for this repo before it can be merged. Please take a moment to checkout the infosec/repoInfo branch, modify .repoInfo.d2l.json to contain the correct info for this repo (see [the docs.dev page](https://docs.dev.d2l/index.php/InfoSec_Process_-_RepoInfo) for details), and merge the completed file into master. If your repo uses docker, you may want to add .repoInfo.d2l.json to your .dockerignore file.

Thanks,
Your InfoSec team