### PR TITLE
DE29488 -- Fix file download on iOS

### DIFF
--- a/src/plugins/generic/download.js
+++ b/src/plugins/generic/download.js
@@ -3,7 +3,7 @@
 var React = require('react');
 
 var isIOS = function() {
-	return /iP[ao]d|iPhone/.test( window.navigator.userAgent );
+	return /iP[ao]d|iPhone/.test(window.navigator.userAgent);
 };
 
 var Download = React.createClass({
@@ -14,8 +14,8 @@ var Download = React.createClass({
 		src: React.PropTypes.string
 	},
 	download: function() {
-		if ( isIOS() ) {
-			window.open( this.props.src );
+		if (isIOS()) {
+			window.open(this.props.src);
 		} else {
 			document.location.href = this.props.src;
 		}

--- a/src/plugins/generic/download.js
+++ b/src/plugins/generic/download.js
@@ -2,6 +2,10 @@
 
 var React = require('react');
 
+var isIOS = function() {
+	return /iP[ao]d|iPhone/.test( window.navigator.userAgent );
+};
+
 var Download = React.createClass({
 	contextTypes : {
 		getIntlMessage: React.PropTypes.func
@@ -10,7 +14,11 @@ var Download = React.createClass({
 		src: React.PropTypes.string
 	},
 	download: function() {
-		document.location.href = this.props.src;
+		if ( isIOS() ) {
+			window.open( this.props.src );
+		} else {
+			document.location.href = this.props.src;
+		}
 	},
 	render: function() {
 		var downloadButtonText = this.context.getIntlMessage('Plugins.Generic.Download');


### PR DESCRIPTION
Fix file download on iOS.

The current implementation fails on iOS, where instead of downloading the file, it attempts to render it inside the iframe without scrollbars, making large plain text files unreadable. For download to work correctly on iOS devices, the download link must be opened in a new "window"