### PR TITLE
Bump 'react-valence-ui-iframe' to semver:^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bower": "^1.6.5",
     "d2l-intl": "^0.2.1",
     "react-frau-intl": "^0.2.0",
-    "react-valence-ui-iframe": "git+https://github.com/Brightspace/react-valence-ui-iframe.git#semver:^3.0.0",
+    "react-valence-ui-iframe": "git+https://github.com/Brightspace/react-valence-ui-iframe.git#semver:^3",
     "url-parse": "^1.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bower": "^1.6.5",
     "d2l-intl": "^0.2.1",
     "react-frau-intl": "^0.2.0",
-    "react-valence-ui-iframe": "git+https://github.com/Brightspace/react-valence-ui-iframe.git#v2.0.0",
+    "react-valence-ui-iframe": "git+https://github.com/Brightspace/react-valence-ui-iframe.git#semver:^3.0.0",
     "url-parse": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump 'react-valence-ui-iframe' to semver:^3.0.0 to solve both: https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F606833376121 and https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F606117775731&fdp=true