### PR TITLE
GAUD-5048 - Use new release token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,4 @@ jobs:
         run: npm run test
       - name: Build Sample
         run: npm run build-sample
-      - name: Report coverage
-        uses: coverallsapp/github-action@v2 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
         uses: BrightspaceUI/actions/semantic-release@main
         with:
           DEFAULT_BRANCH: master
-          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
         run: npm ci
       - name: Lint and Test
         run: npm run test
-      - name: Report coverage
-        uses: coverallsapp/github-action@v2
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@main
         with:

--- a/README.md
+++ b/README.md
@@ -104,13 +104,11 @@ resizeCallback ( size, sizeKnown )
 * True if the size is known.
 * False if the size is not known.
 
-### Bump version ###
+## Versioning and Releasing
 
-```BASH
-$ # npm help 1 version
-$ # npm help 7 semver
-$ npm version [major|minor|patch|premajor|preminor|prepatch|prerelease] -m "chore(version) bump %s"
-$ git push upstream master --tags
+This repo is configured to use `semantic-release`. Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `main`.
+
+To learn how to create major releases and release from maintenance branches, refer to the [semantic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/main/semantic-release) documentation.
 ```
 
 ## Contributing


### PR DESCRIPTION
The `brightspace-bot` and `D2L_GITHUB_TOKEN` are no longer needed for `release` workflows. Instead, we have a [new `D2L_RELEASE_TOKEN`](https://github.com/Brightspace/repo-settings/blob/main/docs/release_action_setup.md) that has the ability to bypass the repo ruleset (configured in https://github.com/Brightspace/repo-settings/pull/1666) and org-level ruleset.

Before merging, I will:
- Confirm the new ruleset matches the old branch protection rule before deleting it
- Remove `brightspace-bot` as a repo contributor
- Confirm the `D2L_RELEASE_TOKEN` is available and remove this repo's access to `D2L_GITHUB_TOKEN`

If you need to make a cert or hotfix, this will need to be backported to the `20.24.03` and `20.24.02` release branches.